### PR TITLE
Add Nuxt Custom 404 Page

### DIFF
--- a/layer0-nuxt-example/layouts/error.vue
+++ b/layer0-nuxt-example/layouts/error.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1 v-if="error.statusCode === 404">This is a custom error page</h1>
+    <h1 v-else>An error occurred</h1>
+    <NuxtLink to="/">Home page</NuxtLink>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: ['error'],
+    layout: 'error' // you can set a custom layout for the error page
+  }
+</script>

--- a/layer0-nuxt-example/nuxt.config.js
+++ b/layer0-nuxt-example/nuxt.config.js
@@ -2,6 +2,9 @@ import fs from 'fs'
 import { join } from 'path'
 
 export default {
+  generate: {
+    fallback: true
+  },
   // Global page headers (https://go.nuxtjs.dev/config-head)
   head: {
     title: 'layer0-nuxt-example',


### PR DESCRIPTION
This does not currently function correctly on Layer0. See https://howie-ross-layer0-nuxt-example-default.layer0.link/404 

This does work correctly and display a custom 404 page using `yarn dev`

